### PR TITLE
Sort entries by date descending

### DIFF
--- a/lib/screens/previous_entries.dart
+++ b/lib/screens/previous_entries.dart
@@ -21,6 +21,7 @@ class PreviousEntriesScreen extends StatelessWidget {
           future: entries.getFiles(),
           builder: (context, AsyncSnapshot<List<DateTime>> snapshot) {
             List<DateTime> datesList = snapshot.data ?? [];
+            datesList.sort((b, a) => a.compareTo(b));
             return ListView.builder(
               itemCount: datesList.length,
               itemBuilder: (context, index) {


### PR DESCRIPTION
Having the previous entries sorted by date descending makes it much easier to find a specific recent one.

Current:
![image](https://user-images.githubusercontent.com/32362869/218574319-074ccdb8-1662-4c51-8398-3756419bc8c7.png)


Proposed:
![image](https://user-images.githubusercontent.com/32362869/218574408-41b5ac08-eb5d-4352-a0a9-a73a54c1374f.png)

